### PR TITLE
change invalid Go version from 1.23.2 to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ashish0kumar/stormy
 
-go 1.23.2
+go 1.23
 
 require (
 	github.com/BurntSushi/toml v1.5.0


### PR DESCRIPTION
The Go toolchain expects the 'go' directive in go.mod to follow the format '1.x', not '1.x.y'. This commit updates the version from '1.23.2' to '1.23' to fix an installation error.

Before Fixing
<img width="1366" height="109" alt="image" src="https://github.com/user-attachments/assets/bb3ab680-0f09-48bf-ad02-2a24eb2436a0" />

After Fixing
<img width="1366" height="139" alt="image" src="https://github.com/user-attachments/assets/95cb53d5-d5da-431d-9d97-c3cd18460c4b" />
