### PR TITLE
feat!: add live mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/ashish0kumar/stormy
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/fatih/color v1.18.0
+	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 h1:qGQQKEcAR99REcMpsXCp3lJ03zYT1PkRd3kQGPn9GVg=
+github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/internal/weather/config.go
+++ b/internal/weather/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 
 	"github.com/BurntSushi/toml"
 )
@@ -18,6 +19,7 @@ type Config struct {
 	Units        string `toml:"units"`
 	ShowCityName bool   `toml:"showcityname"`
 	UseColors    bool   `toml:"use_colors"`
+	LiveMode     bool   `toml:"live_mode"`
 	Compact      bool   `toml:"compact"`
 }
 
@@ -39,6 +41,7 @@ func DefaultConfig() Config {
 		Units:        "metric",
 		ShowCityName: false,
 		UseColors:    false,
+		LiveMode:     false,
 		Compact:      false,
 	}
 }
@@ -178,6 +181,12 @@ func ReadConfig() Config {
 			}
 			if useColors, ok := partialConfig["use_colors"].(bool); ok {
 				defaultConfig.UseColors = useColors
+			}
+			if liveMode, ok := partialConfig["live_mode"].(bool); ok {
+				defaultConfig.LiveMode = liveMode
+			}
+			if compact, ok := partialConfig["compact"].(bool); ok {
+				defaultConfig.Compact = compact
 			}
 		}
 

--- a/internal/weather/config.go
+++ b/internal/weather/config.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 
 	"github.com/BurntSushi/toml"
 )

--- a/main.go
+++ b/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/ashish0kumar/stormy/internal/weather"
+	"github.com/k0kubun/go-ansi"
 )
 
 // version is set during build time using -ldflags
@@ -42,6 +44,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Run '%s --help' for usage information.\n", os.Args[0])
 	}
 
+	fetchAndDisplay(config, false)
+}
+
+// fetchAndDisplay fetches weather data and displays it according to the given configuration.
+// clear determines whether the screen should be cleared before displaying updated information.
+func fetchAndDisplay(config weather.Config, clear bool) {
 	// Fetch weather data
 	weatherData, err := weather.FetchWeather(config)
 	if err != nil {
@@ -50,6 +58,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Clear screen in live mode
+	if clear {
+		_, _ = ansi.Printf("\x1b[%dA\x1b[J", 7) // maximum number of displayed lines
+	}
+
 	// Display the weather
 	weather.DisplayWeather(weatherData, config)
+
+	// Loop in live mode
+	if !config.LiveMode {
+		return
+	}
+	time.Sleep(15 * time.Second)
+	fetchAndDisplay(config, true)
 }


### PR DESCRIPTION
Hi there! First, congrats on the quality of your work, both in terms of features and of code quality. It made adding my feature effortless!

I just saw your project on Twitter a few hours ago and wanted to contribute with a live mode.

Essentially, it periodically refreshes the terminal output with new data, so the program appears to be running live :) I thought this would be an interesting option, for example if you want to spin stormy up in the corner of your screen and leave it running for a while.

Technically, this PR:
- extracts the fetch & display logic into a function that gets recursively called by itself every 15s (a good number in my opinion — good balance between "live" feeling and no API spam), clearing **only the printed line, not the whole console**, at each recursive call
- adds a new `live_mode` boolean config value
- adds the [`go-ansi`](github.com/k0kubun/go-ansi) library to automatically support Windows for screen clearing (not tested as I have no Windows device available)
- fixes the missing parsing of the `compact` option in the partial config function part, as I went there for my purpose

Now, there are a few things we could argue about to make the feature fit your vision better:
1. Should I add a flag alongside the config value? Remove the config value? _My vision for that: a config value is ideal because you can simply call `stormy` without any arg, and as the command input is not cleared by the live mode, it stays on the screen; it looks overall much better than having an always-on-screen flag_
2. Is the hardcoded `7` for the line count okay for you? I don't like it very much, but that's the only way to get this info before requiring extracting/exporting some variables or functions from somewhere else. What's the best way to do it? I'd extract the `icon` map from `getIcon` and compute the line count for `Unknown`, from the top of my head
3. Should the refresh duration be configurable? Through a flag or config? Should it be merged with the `live_mode` boolean, e.g., an int that would be `0` for no live mode and + for enabled with the said duration?
4. Is the added function in a good place for you? I saw you tried to only keep `main()` in the main file, but I couldn't think of a good other place for this one without creating a new file, as it's an in-between of data fetching and displaying

Also, as a side note about the line count, it doesn't take into account if the user presses Enter one or more times between 2 refreshes, effectively breaking the displayed text. I couldn't figure out a good way to handle that that would work, and work on Windows too. As it's not a big deal in my opinion, I didn't bother handling this case at all for maintainability reasons.

So yeah, what do you think?


_Side note: if you like my work, I have a bunch of small/medium fixes & features I could make other PRs for pretty quickly! Don't release a new version right after merging this one if you happen to do so :)_