### PR TITLE
feat(open-meteo): display formatted city name for OpenMeteo

### DIFF
--- a/internal/weather/models.go
+++ b/internal/weather/models.go
@@ -198,7 +198,7 @@ func FetchWeatherOpenMeteo(config Config) (*Weather, error) {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
-	weather := ConvertOpenMeteoToWeather(openMeteoWeather, config.City)
+	weather := ConvertOpenMeteoToWeather(openMeteoWeather, cityGeo.Name)
 
 	return &weather, nil
 }


### PR DESCRIPTION
When using OpenMeteo, use the formatted city name from the API result instead of the raw string from the config. This is a good QOL change, but also a parity one, as OpenWeatherMap already does it this way.