### PR TITLE
perf: slightly improve memory allocation & code

### DIFF
--- a/internal/weather/config.go
+++ b/internal/weather/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 
 	"github.com/BurntSushi/toml"
 )
@@ -92,12 +93,9 @@ func ValidateConfig(config *Config) {
 	}
 
 	// Validate units
-	validUnits := map[string]bool{
-		"metric":   true,
-		"imperial": true,
-	}
+	validUnits := []string{"metric", "imperial"}
 
-	if !validUnits[config.Units] {
+	if !slices.Contains(validUnits, config.Units) {
 		fmt.Fprintln(os.Stderr, "Warning: Invalid units in config. Using 'metric' as default.")
 		config.Units = "metric"
 	}
@@ -135,8 +133,7 @@ func ReadConfig() Config {
 		}
 		defer file.Close()
 
-		encoder := toml.NewEncoder(file)
-		if err := encoder.Encode(defaultConfig); err != nil {
+		if err := toml.NewEncoder(file).Encode(defaultConfig); err != nil {
 			fmt.Fprintln(os.Stderr, "Failed to write default config:", err)
 			return defaultConfig
 		}
@@ -159,7 +156,7 @@ func ReadConfig() Config {
 
 		// Try to load partial config
 		defaultConfig := DefaultConfig()
-		var partialConfig map[string]interface{}
+		var partialConfig map[string]any
 
 		if err := toml.Unmarshal(data, &partialConfig); err == nil {
 			// Apply any valid values from partial config
@@ -197,8 +194,7 @@ func ReadConfig() Config {
 		}
 		defer file.Close()
 
-		encoder := toml.NewEncoder(file)
-		if err := encoder.Encode(defaultConfig); err != nil {
+		if err := toml.NewEncoder(file).Encode(defaultConfig); err != nil {
 			fmt.Fprintln(os.Stderr, "Failed to write merged config:", err)
 		}
 

--- a/internal/weather/display.go
+++ b/internal/weather/display.go
@@ -28,8 +28,7 @@ func getWindDirectionSymbol(degrees int) string {
 // DisplayWeather renders the weather data with ASCII art
 func DisplayWeather(weather *Weather, config Config) {
 	// Get main weather condition
-	var mainWeather string
-	var description string
+	var mainWeather, description string
 	var weatherID int
 	if len(weather.Weather) > 0 {
 		mainWeather = weather.Weather[0].Main
@@ -42,8 +41,7 @@ func DisplayWeather(weather *Weather, config Config) {
 	}
 
 	// Determine units based on config
-	windSpeedUnits := "km/h"
-	tempUnit := "°C"
+	var windSpeedUnits, tempUnit string
 
 	// Convert wind speed based on provider and units
 	windSpeed := weather.Wind.Speed
@@ -85,7 +83,8 @@ func DisplayWeather(weather *Weather, config Config) {
 		popPercent = int(math.Round(weather.Pop * 100))
 	}
 
-	var labels, values []string
+	labels := make([]string, 0, 6)
+	values := make([]string, 0, cap(labels))
 
 	// City name display
 	cityName := weather.Name
@@ -111,14 +110,15 @@ func DisplayWeather(weather *Weather, config Config) {
 		values = append(values, fmt.Sprintf("%.1f%s", temperature, tempUnit))
 
 		labels = append(labels, "Wind ")
-		values = append(values, fmt.Sprintf("%.1f %s %s", windSpeed, windSpeedUnits, getWindDirectionSymbol(weather.Wind.Deg)))
+		values = append(
+			values, fmt.Sprintf("%.1f %s %s", windSpeed, windSpeedUnits, getWindDirectionSymbol(weather.Wind.Deg)),
+		)
 
 		labels = append(labels, "Humidity ")
 		values = append(values, fmt.Sprintf("%d%%", weather.Main.Humidity))
 
 		labels = append(labels, "Precip ")
 		values = append(values, fmt.Sprintf("%.1f mm | %d%%", precipMM, popPercent))
-
 	} else {
 		// Compact mode doesn't use labels in the same way
 		weatherDisplay := description
@@ -217,7 +217,7 @@ func displayWeatherArtAligned(mainWeather string, weatherID int, labels, values 
 	}
 
 	// Prepare the text lines
-	var textLines []string
+	textLines := make([]string, 0, len(labels)+2)
 	textLines = append(textLines, "") // Empty line to match icon top spacing
 
 	// Add formatted lines with aligned labels and values
@@ -247,8 +247,10 @@ func displayWeatherArtAligned(mainWeather string, weatherID int, labels, values 
 }
 
 // displayWeatherArtCompact shows ASCII art with compact formatting
-func displayWeatherArtCompact(mainWeather string, weatherID int, cityName, weatherDisplay,
-	tempDisplay, windDisplay, humidityDisplay, precipDisplay string, config Config) {
+func displayWeatherArtCompact(
+	mainWeather string, weatherID int, cityName, weatherDisplay,
+	tempDisplay, windDisplay, humidityDisplay, precipDisplay string, config Config,
+) {
 
 	// Get the weather icon
 	iconLines := getWeatherIcon(mainWeather, weatherID, config.UseColors)
@@ -272,7 +274,7 @@ func displayWeatherArtCompact(mainWeather string, weatherID int, cityName, weath
 	}
 
 	// Prepare the text lines
-	var textLines []string
+	textLines := make([]string, 0, 5)
 	textLines = append(textLines, "") // Empty line to match icon top spacing
 
 	if cityName != "" && config.ShowCityName {


### PR DESCRIPTION
- **Replace a map with a slice for a smaller footprint**
- Replace the only `interface{}` by `any` because it's the same thing, but prettier
- Remove duplicate value definition for temperature units
- **Pre-allocate slices' capacities for faster `append()`s**
- Misc opinionated nitpicks in formatting (helped by my IDE auto-format)