### PR TITLE
fix(open-meteo): clarify error message for complex queries

### DIFF
--- a/internal/weather/models.go
+++ b/internal/weather/models.go
@@ -2,16 +2,20 @@ package weather
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const (
 	ProviderOpenWeatherMap = "OpenWeatherMap"
 	ProviderOpenMeteo      = "OpenMeteo"
 )
+
+var ErrUnsupportedQuery = errors.New("unsupported query")
 
 type OpenMeteoWeather struct {
 	Latitude  float64 `json:"latitude"`
@@ -173,6 +177,9 @@ func FetchWeatherOpenMeteo(config Config) (*Weather, error) {
 
 	cityGeo, err := GetFirstGeoResult(encodedCity)
 	if err != nil {
+		if strings.Contains(config.City, " ") || strings.Contains(config.City, ",") {
+			return nil, fmt.Errorf("geocoding failed - %w: %w", ErrUnsupportedQuery, err)
+		}
 		return nil, fmt.Errorf("geocoding failed: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -67,7 +68,11 @@ func fetchAndDisplay(config weather.Config, clear bool) {
 	weatherData, err := weather.FetchWeather(config)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fetch weather data: %v\n", err)
-		fmt.Fprintln(os.Stderr, "Please check your internet connection and API key.")
+		if errors.Is(err, weather.ErrUnsupportedQuery) {
+			fmt.Fprintln(os.Stderr, "Detailed queries are not supported by OpenMeteo, try using other providers.")
+		} else {
+			fmt.Fprintln(os.Stderr, "Please check your internet connection and API key.")
+		}
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Resolves #5

Improve the displayed errors to mitigate cases where users are being too precise with their inputs, clarifying the problem and what they need to do.

<img width="700" alt="demo" src="https://github.com/user-attachments/assets/f3b66e24-8de6-443c-94f0-1647a447f2c8" />