### PR TITLE
refactor(open-weather-map): use newer APIs instead of the deprecated one

### DIFF
--- a/internal/weather/models.go
+++ b/internal/weather/models.go
@@ -17,6 +17,17 @@ const (
 
 var ErrUnsupportedQuery = errors.New("unsupported query")
 
+type GeoResult struct {
+	ID        int     `json:"id"`
+	Name      string  `json:"name"`
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+type GeoResponse struct {
+	Results []GeoResult `json:"results"`
+}
+
 type OpenMeteoWeather struct {
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
@@ -32,64 +43,126 @@ type OpenMeteoWeather struct {
 	} `json:"current"`
 }
 
-// Weather holds the weather data returned by the API
-type Weather struct {
+type OpenWeatherMapGeolocationResult struct {
+	City       string            `json:"name"`
+	LocalNames map[string]string `json:"local_names"`
+	Latitude   float64           `json:"lat"`
+	Longitude  float64           `json:"lon"`
+	Country    string            `json:"country"`
+	State      string            `json:"state"`
+}
+
+type OpenWeatherMapWeather struct {
+	Coordinates struct {
+		Lon float64 `json:"lon"`
+		Lat float64 `json:"lat"`
+	} `json:"coord"`
 	Weather []struct {
 		ID          int    `json:"id"`
 		Main        string `json:"main"`
 		Description string `json:"description"`
 	} `json:"weather"`
+	Base string `json:"base"`
 	Main struct {
-		Temp     float64 `json:"temp"`
-		Humidity int     `json:"humidity"`
+		Temperature          float64 `json:"temp"`
+		FeelsLikeTemperature float64 `json:"feels_like"`
+		TempMin              float64 `json:"temp_min"`
+		TempMax              float64 `json:"temp_max"`
+		Pressure             int     `json:"pressure"`
+		Humidity             int     `json:"humidity"`
+		SeaLevelPressure     int     `json:"sea_level"`
+		GroundLevelPressure  int     `json:"grnd_level"`
 	} `json:"main"`
-	Wind struct {
-		Speed float64 `json:"speed"`
-		Deg   int     `json:"deg"`
+	VisibilityDistance int `json:"visibility"`
+	Wind               struct {
+		Speed   float64 `json:"speed"`
+		Degrees int     `json:"deg"`
+		Gust    float64 `json:"gust"`
 	} `json:"wind"`
-	Rain struct {
-		OneHour float64 `json:"1h"`
-	} `json:"rain"`
 	Clouds struct {
 		All int `json:"all"`
 	} `json:"clouds"`
-	Pop  float64 `json:"pop"`
-	Name string  `json:"name"`
-	Dt   int64   `json:"dt"`
+	Rain struct {
+		Precipitations float64 `json:"1h,omitempty"`
+	} `json:"rain,omitempty"`
+	Snow struct {
+		Precipitations float64 `json:"1h,omitempty"`
+	} `json:"snow,omitempty"`
+	CalculationDate int `json:"dt"`
+	Sys             struct {
+		Type        int    `json:"type"`
+		Id          int    `json:"id"`
+		Country     string `json:"country"`
+		SunriseTime int    `json:"sunrise"`
+		SunsetTime  int    `json:"sunset"`
+	} `json:"sys"`
+	TimezoneShift int    `json:"timezone"`
+	ID            int    `json:"id"`
+	City          string `json:"name"`
+	Cod           int    `json:"cod"`
 }
 
-type GeoResult struct {
-	ID        int     `json:"id"`
-	Name      string  `json:"name"`
-	Latitude  float64 `json:"latitude"`
-	Longitude float64 `json:"longitude"`
+// Weather holds the weather data returned by the API
+type Weather struct {
+	Weather []struct {
+		ID          int
+		Main        string
+		Description string
+	}
+	Main struct {
+		Temp     float64
+		Humidity int
+	}
+	Wind struct {
+		Speed float64
+		Deg   int
+	}
+	Rain struct {
+		OneHour float64
+	}
+	Clouds struct {
+		All int
+	}
+	Pop  float64
+	Name string
+	Dt   int64
 }
 
-type GeoResponse struct {
-	Results []GeoResult `json:"results"`
+func fetchAndUnmarshal[T any](u string, args ...any) (out T, err error) {
+	var resp *http.Response
+	resp, err = http.Get(fmt.Sprintf(u, args...))
+	if err != nil {
+		return
+	}
+	defer func(body io.ReadCloser) {
+		_ = body.Close()
+	}(resp.Body)
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		err = fmt.Errorf("invalid API key - please check your configuration")
+		return
+	} else if resp.StatusCode == http.StatusNotFound {
+		err = fmt.Errorf("no data found - please check your input")
+		return
+	} else if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("API returned status code %d", resp.StatusCode)
+		return
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&out)
+	return
 }
 
 func GetFirstGeoResult(encodedCity string) (*GeoResult, error) {
-	cityUrl := fmt.Sprintf("https://geocoding-api.open-meteo.com/v1/search?name=%s&count=1", encodedCity)
-
-	resp, err := http.Get(cityUrl)
+	geo, err := fetchAndUnmarshal[GeoResponse](
+		"https://geocoding-api.open-meteo.com/v1/search?name=%s&count=1", encodedCity,
+	)
 	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var geo GeoResponse
-	if err := json.Unmarshal(body, &geo); err != nil {
 		return nil, err
 	}
 
 	if len(geo.Results) == 0 {
-		return nil, fmt.Errorf("no results found for city query %s", encodedCity)
+		return nil, fmt.Errorf("no results found for city query \"%s\"", encodedCity)
 	}
 
 	return &geo.Results[0], nil
@@ -131,9 +204,9 @@ func WeatherCodeToSentence(code int) string {
 func ConvertOpenMeteoToWeather(om OpenMeteoWeather, cityName string) Weather {
 	return Weather{
 		Weather: []struct {
-			ID          int    `json:"id"`
-			Main        string `json:"main"`
-			Description string `json:"description"`
+			ID          int
+			Main        string
+			Description string
 		}{
 			{
 				ID:          om.Current.WeatherCode,
@@ -142,32 +215,69 @@ func ConvertOpenMeteoToWeather(om OpenMeteoWeather, cityName string) Weather {
 			},
 		},
 		Main: struct {
-			Temp     float64 `json:"temp"`
-			Humidity int     `json:"humidity"`
+			Temp     float64
+			Humidity int
 		}{
 			Temp:     om.Current.Temperature2m,
 			Humidity: om.Current.RelativeHumidity2m,
 		},
 		Wind: struct {
-			Speed float64 `json:"speed"`
-			Deg   int     `json:"deg"`
+			Speed float64
+			Deg   int
 		}{
 			Speed: om.Current.WindSpeed10m,
 			Deg:   om.Current.WindDirection10m,
 		},
 		Rain: struct {
-			OneHour float64 `json:"1h"`
+			OneHour float64
 		}{
 			OneHour: om.Current.Precipitation,
 		},
 		Clouds: struct {
-			All int `json:"all"`
+			All int
 		}{
 			All: 0, // Not provided by Open-Meteo
 		},
 		Pop:  0, // Not provided by Open-Meteo
 		Name: cityName,
 		Dt:   0, // You could parse om.Current.Time to a Unix timestamp if needed
+	}
+}
+
+func ConvertOpenWeatherMapToWeather(om OpenWeatherMapWeather, cityName string) Weather {
+	return Weather{
+		Weather: []struct {
+			ID          int
+			Main        string
+			Description string
+		}(om.Weather),
+		Main: struct {
+			Temp     float64
+			Humidity int
+		}{
+			Temp:     om.Main.Temperature,
+			Humidity: om.Main.Humidity,
+		},
+		Wind: struct {
+			Speed float64
+			Deg   int
+		}{
+			Speed: om.Wind.Speed,
+			Deg:   om.Wind.Degrees,
+		},
+		Rain: struct {
+			OneHour float64
+		}{
+			OneHour: om.Rain.Precipitations,
+		},
+		Clouds: struct {
+			All int
+		}{
+			All: om.Clouds.All,
+		},
+		Pop:  0, // Not provided (anymore) by OpenWeatherMap
+		Name: cityName,
+		Dt:   int64(om.CalculationDate),
 	}
 }
 
@@ -183,26 +293,13 @@ func FetchWeatherOpenMeteo(config Config) (*Weather, error) {
 		return nil, fmt.Errorf("geocoding failed: %w", err)
 	}
 
-	apiURL := fmt.Sprintf(
+	openMeteoWeather, err := fetchAndUnmarshal[OpenMeteoWeather](
 		"https://api.open-meteo.com/v1/forecast?latitude=%f&longitude=%f&current=temperature_2m,weather_code,precipitation,relative_humidity_2m,wind_speed_10m,wind_direction_10m&wind_speed_unit=kmh&temperature_unit=celsius",
 		cityGeo.Latitude,
 		cityGeo.Longitude,
 	)
-
-	resp, err := http.Get(apiURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch weather data: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	var openMeteoWeather OpenMeteoWeather
-	if err := json.Unmarshal(body, &openMeteoWeather); err != nil {
-		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+		return nil, fmt.Errorf("failed to fetch or decode data: %w", err)
 	}
 
 	weather := ConvertOpenMeteoToWeather(openMeteoWeather, cityGeo.Name)
@@ -214,35 +311,32 @@ func FetchWeatherOpenWeatherMap(config Config) (*Weather, error) {
 	// URL encode the city parameter
 	encodedCity := url.QueryEscape(config.City)
 
-	apiURL := fmt.Sprintf(
-		"https://api.openweathermap.org/data/2.5/weather?q=%s&units=metric&APPID=%s",
+	// Geocoding
+	geoResult, err := fetchAndUnmarshal[[]OpenWeatherMapGeolocationResult](
+		"https://api.openweathermap.org/geo/1.0/direct?q=%s&limit=1&appid=%s",
 		encodedCity,
 		config.ApiKey,
 	)
-
-	resp, err := http.Get(apiURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("invalid API key - please check your configuration")
-	} else if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("city '%s' not found - please check the spelling", config.City)
-	} else if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status code %d", resp.StatusCode)
+		return nil, fmt.Errorf("failed to fetch or decode data for geocoding: %w", err)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	if len(geoResult) == 0 {
+		return nil, fmt.Errorf("no results found for city %s", config.City)
+	}
+
+	// Actual weather
+	openWeatherMapWeather, err := fetchAndUnmarshal[OpenWeatherMapWeather](
+		"https://api.openweathermap.org/data/2.5/weather?lat=%f&lon=%f&units=metric&appid=%s",
+		geoResult[0].Latitude,
+		geoResult[0].Longitude,
+		config.ApiKey,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, fmt.Errorf("failed to fetch or decode data: %w", err)
 	}
 
-	var weather Weather
-	if err := json.Unmarshal(body, &weather); err != nil {
-		return nil, fmt.Errorf("failed to parse JSON: %w", err)
-	}
+	weather := ConvertOpenWeatherMapToWeather(openWeatherMapWeather, geoResult[0].City)
 
 	return &weather, nil
 }

--- a/main.go
+++ b/main.go
@@ -62,8 +62,8 @@ func main() {
 }
 
 // fetchAndDisplay fetches weather data and displays it according to the given configuration.
-// clear determines whether the screen should be cleared before displaying updated information.
-func fetchAndDisplay(config weather.Config, clear bool) {
+// clearDisplay determines whether the screen should be cleared before displaying updated information.
+func fetchAndDisplay(config weather.Config, clearDisplay bool) {
 	// Fetch weather data
 	weatherData, err := weather.FetchWeather(config)
 	if err != nil {
@@ -77,7 +77,7 @@ func fetchAndDisplay(config weather.Config, clear bool) {
 	}
 
 	// Clear screen in live mode
-	if clear {
+	if clearDisplay {
 		_, _ = ansi.Printf("\x1b[%dA\x1b[J", 7) // maximum number of displayed lines
 	}
 
@@ -88,7 +88,7 @@ func fetchAndDisplay(config weather.Config, clear bool) {
 	if !config.LiveMode {
 		return
 	}
-	if !clear {
+	if !clearDisplay {
 		// hide cursor on live mode startup
 		_, _ = ansi.Print("\x1b[?25l")
 	}


### PR DESCRIPTION
This is a transparent API upgrade; nothing will change for the user (except doing 2 requests instead of one).

This PR upgrades the API calls for OpenWeatherMap from using the one with built-in geocoding, now [deprecated](https://openweathermap.org/current#builtin), to using a separate geocoding step.

Despite doubling the amount of requests, it's in par with what OpenMeteo already does.

The following changes have also been made:
- Create an intermediate `fetchAndUnmarshal` function that uses generics to factorize the logic for the several fetch calls, ensuring similar processing for all of them (alongside providing a built-in `fmt.Sprintf` call)
  - _Note: the errors have slightly changed as they are now shared by all fetch calls, they have been generalized and are sometimes less precise; I still consider the maintenance tradeoff worth it_
- As the new API calls have different types from the deprecated one:
  - a conversion function has also been added, also in par with OpenMeteo
  - JSON annotations have been removed from the main `Weather` structure

#### Additional changes
- Quote the encoded query text outputted in the error for a prettier look
- Rename `clear` to `clearDisplay` to avoid name shadowing with Go's built-in [`clear` function](https://pkg.go.dev/builtin#clear)