### PR TITLE
feat: support user defined longitude and latitude

### DIFF
--- a/internal/weather/config.go
+++ b/internal/weather/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	Provider     string `toml:"provider"`
 	ApiKey       string `toml:"api_key"`
 	City         string `toml:"city"`
+	Longitude    string `toml:"longitude"`
+	Latitude     string `toml:"latitude"`
 	Units        string `toml:"units"`
 	ShowCityName bool   `toml:"showcityname"`
 	UseColors    bool   `toml:"use_colors"`
@@ -26,8 +28,8 @@ type Config struct {
 
 // Flags holds command line flags
 type Flags struct {
-	City, Units            string
-	Compact, Help, Version bool
+	City, Units, Longitude, Latitude string
+	Compact, Help, Version           bool
 }
 
 const (
@@ -43,6 +45,8 @@ func DefaultConfig() Config {
 		Provider:     ProviderOpenMeteo,
 		ApiKey:       "",
 		City:         "",
+		Longitude:    "",
+		Latitude:     "",
 		Units:        UnitMetric,
 		ShowCityName: false,
 		UseColors:    true,
@@ -177,6 +181,12 @@ func ReadConfig() Config {
 			if city, ok := partialConfig["city"].(string); ok {
 				defaultConfig.City = city
 			}
+			if longitude, ok := partialConfig["longitude"].(string); ok {
+				defaultConfig.Longitude = longitude
+			}
+			if latitude, ok := partialConfig["latitude"].(string); ok {
+				defaultConfig.Latitude = latitude
+			}
 			if units, ok := partialConfig["units"].(string); ok {
 				defaultConfig.Units = units
 			}
@@ -221,6 +231,8 @@ func ReadConfig() Config {
 // ParseFlags parses command line flags
 func ParseFlags() (flags Flags) {
 	flag.StringVar(&flags.City, "city", "", "City to get weather for")
+	flag.StringVar(&flags.Longitude, "longitude", "", "Longitude coordinate to get weather for")
+	flag.StringVar(&flags.Latitude, "latitude", "", "Latitude coordinate to get weather for")
 	flag.StringVar(&flags.Units, "units", "", fmt.Sprintf("Units (%s)", strings.Join(validUnits[:], ", ")))
 	flag.BoolVar(&flags.Compact, "compact", false, "Compact display mode")
 	flag.BoolVar(&flags.Help, "help", false, "Show help")
@@ -248,6 +260,12 @@ func ParseFlags() (flags Flags) {
 func ApplyFlags(config *Config, flags Flags) {
 	if flags.City != "" {
 		config.City = flags.City
+	}
+	if flags.Longitude != "" {
+		config.Longitude = flags.Longitude
+	}
+	if flags.Latitude != "" {
+		config.Latitude = flags.Latitude
 	}
 	if flags.Units != "" {
 		config.Units = flags.Units

--- a/internal/weather/display.go
+++ b/internal/weather/display.go
@@ -119,7 +119,7 @@ func DisplayWeather(weather *Weather, config Config) {
 		cityName = config.City
 	}
 
-	if config.ShowCityName {
+	if config.ShowCityName && cityName != "" {
 		if !config.Compact {
 			labels = append(labels, "City")
 			values = append(values, cityName)

--- a/internal/weather/models.go
+++ b/internal/weather/models.go
@@ -271,61 +271,79 @@ func ConvertOpenWeatherMapToWeather(om OpenWeatherMapWeather, cityName string) W
 }
 
 func FetchWeatherOpenMeteo(config Config) (*Weather, error) {
-	// URL-encode the city name before passing to geocoding
-	encodedCity := url.QueryEscape(config.City)
+	var latitude, longitude any;
+	var city string;
 
-	cityGeo, err := GetFirstGeoResult(encodedCity)
-	if err != nil {
-		if strings.Contains(config.City, " ") || strings.Contains(config.City, ",") {
-			return nil, fmt.Errorf("geocoding failed - %w: %w", ErrUnsupportedQuery, err)
+	if (config.City != "") {
+		// URL-encode the city name before passing to geocoding
+		encodedCity := url.QueryEscape(config.City)
+
+		cityGeo, err := GetFirstGeoResult(encodedCity)
+		if err != nil {
+			if strings.Contains(config.City, " ") || strings.Contains(config.City, ",") {
+				return nil, fmt.Errorf("geocoding failed - %w: %w", ErrUnsupportedQuery, err)
+			}
+			return nil, fmt.Errorf("geocoding failed: %w", err)
 		}
-		return nil, fmt.Errorf("geocoding failed: %w", err)
-	}
+
+		latitude, longitude, city  = cityGeo.Latitude, cityGeo.Longitude, cityGeo.Name
+	} else {
+		latitude, longitude  = config.Latitude, config.Longitude
+	} 
 
 	openMeteoWeather, err := fetchAndUnmarshal[OpenMeteoWeather](
-		"https://api.open-meteo.com/v1/forecast?latitude=%f&longitude=%f&current=temperature_2m,weather_code,precipitation,relative_humidity_2m,wind_speed_10m,wind_direction_10m&wind_speed_unit=kmh&temperature_unit=celsius",
-		cityGeo.Latitude,
-		cityGeo.Longitude,
+		"https://api.open-meteo.com/v1/forecast?latitude=%v&longitude=%v&current=temperature_2m,weather_code,precipitation,relative_humidity_2m,wind_speed_10m,wind_direction_10m&wind_speed_unit=kmh&temperature_unit=celsius",
+		latitude,
+		longitude,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch or decode data: %w", err)
 	}
 
-	weather := ConvertOpenMeteoToWeather(openMeteoWeather, cityGeo.Name)
+	weather := ConvertOpenMeteoToWeather(openMeteoWeather, city)
 
 	return &weather, nil
 }
 
 func FetchWeatherOpenWeatherMap(config Config) (*Weather, error) {
-	// URL encode the city parameter
-	encodedCity := url.QueryEscape(config.City)
+	var longitude, latitude any;
+	var city string;
 
-	// Geocoding
-	geoResult, err := fetchAndUnmarshal[[]OpenWeatherMapGeolocationResult](
-		"https://api.openweathermap.org/geo/1.0/direct?q=%s&limit=1&appid=%s",
-		encodedCity,
-		config.ApiKey,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch or decode data for geocoding: %w", err)
-	}
+	if (config.City != "") {
+		// URL encode the city parameter
+		encodedCity := url.QueryEscape(config.City)
 
-	if len(geoResult) == 0 {
-		return nil, fmt.Errorf("no results found for city %s", config.City)
+		// Geocoding
+		geoResult, err := fetchAndUnmarshal[[]OpenWeatherMapGeolocationResult](
+			"https://api.openweathermap.org/geo/1.0/direct?q=%s&limit=1&appid=%s",
+			encodedCity,
+			config.ApiKey,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch or decode data for geocoding: %w", err)
+		}
+
+		if len(geoResult) == 0 {
+			return nil, fmt.Errorf("no results found for city %s", config.City)
+		}
+
+		latitude, longitude, city = geoResult[0].Latitude, geoResult[0].Longitude, geoResult[0].City
+	} else {
+		latitude, longitude = config.Longitude, config.Latitude
 	}
 
 	// Actual weather
 	openWeatherMapWeather, err := fetchAndUnmarshal[OpenWeatherMapWeather](
-		"https://api.openweathermap.org/data/2.5/weather?lat=%f&lon=%f&units=metric&appid=%s",
-		geoResult[0].Latitude,
-		geoResult[0].Longitude,
+		"https://api.openweathermap.org/data/2.5/weather?lat=%v&lon=%v&units=metric&appid=%s",
+		latitude,
+		longitude,
 		config.ApiKey,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch or decode data: %w", err)
 	}
 
-	weather := ConvertOpenWeatherMapToWeather(openWeatherMapWeather, geoResult[0].City)
+	weather := ConvertOpenWeatherMapToWeather(openWeatherMapWeather, city)
 
 	return &weather, nil
 }

--- a/main.go
+++ b/main.go
@@ -102,8 +102,8 @@ func main() {
 	weather.ApplyFlags(&config, flags)
 
 	// Check if the city is set
-	if config.City == "" {
-		_, _ = fmt.Fprintln(os.Stderr, "Error: City must be set in the config file or via command line flags")
+	if config.City == "" && (config.Latitude == "" || config.Longitude == "") {
+		_, _ = fmt.Fprintln(os.Stderr, "Error: City or Longitude and Latitude must be set in the config file or via command line flags")
 		_, _ = fmt.Fprintln(os.Stderr, "Config file location:", weather.GetConfigPath())
 		_, _ = fmt.Fprintf(os.Stderr, "Run '%s --help' for usage information.\n", os.Args[0])
 		os.Exit(1)


### PR DESCRIPTION
As discussed in #6, this PR allows the user to specify a set of longitude and latitude coordinates instead of a city name. This implementation has the city being used if the user specifies both city and coordinates, but I don't really have a strong preference on that if folks think it should be changed.